### PR TITLE
just enough to follow instrux in README

### DIFF
--- a/contrib/help.scm
+++ b/contrib/help.scm
@@ -35,14 +35,14 @@
 ;                    (symbol? '())           ==>  #f
 ;                    (symbol? #f)            ==>  #f
 
-(load-from-library "make-help-index.scm")
-(load-from-library "find-help-page.scm")
-(load-from-library "read-line.scm")
-(load-from-library "string-find.scm")
-(load-from-library "mergesort.scm")
-(load-from-library "flatten.scm")
-(load-from-library "list-to-set.scm")
-(load-from-library "filter.scm")
+(load-from-library "./lib/make-help-index.scm")
+(load-from-library "./lib/find-help-page.scm")
+(load-from-library "./lib/read-line.scm")
+(load-from-library "./lib/string-find.scm")
+(load-from-library "./lib/mergesort.scm")
+(load-from-library "./lib/flatten.scm")
+(load-from-library "./lib/list-to-set.scm")
+(load-from-library "./lib/filter.scm")
 
 (define *lines-per-page* (if (eq? *host-system* 'plan9) #f 23))
 

--- a/ext/sys-unix/unix.c
+++ b/ext/sys-unix/unix.c
@@ -598,6 +598,7 @@ cell pp_sys_readlink(void) {
 	char	buf[MAXPATHLEN+1];
 	int	k;
 
+  int readlink(char*, char*, int);
 	k = readlink(string(parg(1)), buf, MAXPATHLEN);
 	if (k < 0) return sys_error("sys:readlink");
 	buf[k] = 0;
@@ -823,6 +824,7 @@ cell pp_sys_strerror(void) {
 }
 
 cell pp_sys_symlink(void) {
+  int symlink(char*, char*);
 	if (symlink(string(parg(1)), string(parg(2))) < 0)
 		return sys_error("sys:symlink");
 	return sys_ok();
@@ -880,6 +882,8 @@ cell pp_sys_unlock(void) {
 cell pp_sys_usleep(void) {
 #if __FreeBSD__ == 7
 	int usleep(useconds_t microseconds);
+#else
+  int usleep(int);
 #endif
 	if (usleep(integer_value("sys:usleep", parg(1))))
 		return sys_error("sys:usleep");

--- a/lib/define-structure.scm
+++ b/lib/define-structure.scm
@@ -57,9 +57,9 @@
 ;              (list (point? p)
 ;                    (point-color p)))       ==>  (#t yellow)
 
-(load-from-library "iota.scm")
-(load-from-library "subvector.scm")
-(load-from-library "duplicates.scm")
+(load-from-library "./lib/iota.scm")
+(load-from-library "./lib/subvector.scm")
+(load-from-library "./lib/duplicates.scm")
 
 (define-syntax (define-structure name . slots)
   (if (not (symbol? name))

--- a/lib/duplicates.scm
+++ b/lib/duplicates.scm
@@ -24,7 +24,7 @@
 ;            (dupv '(#\a #\b #\a #\c))    ==>  (#\a)
 ;            (dupq '(a b c d a c e f c))  ==>  (a c)
 
-(load-from-library "memp.scm")
+(load-from-library "./lib/memp.scm")
 
 (define (dupp p x)
   (letrec

--- a/lib/find-help-page.scm
+++ b/lib/find-help-page.scm
@@ -13,7 +13,7 @@
 ;
 ; (Example): (find-help-page "help")  ==>  "path to help-page"
 
-(load-from-library "name-to-file-name.scm")
+(load-from-library "./lib/name-to-file-name.scm")
 
 (define (find-help-page s)
 

--- a/lib/hash-table.scm
+++ b/lib/hash-table.scm
@@ -57,10 +57,10 @@
 ;              (hash-table-set! h "key" 'value)
 ;              (hash-table-ref  h "key"))        ==>  (value)
 
-(load-from-library "count.scm")
-(load-from-library "assp.scm")
-(load-from-library "keyword-value.scm")
-(load-from-library "define-structure.scm")
+(load-from-library "./lib/count.scm")
+(load-from-library "./lib/assp.scm")
+(load-from-library "./lib/keyword-value.scm")
+(load-from-library "./lib/define-structure.scm")
 
 (define-structure ht (len 0) (test equal?) table)
 

--- a/lib/list-to-set.scm
+++ b/lib/list-to-set.scm
@@ -10,7 +10,7 @@
 ;
 ; Example:   (list->set '(a b c b c))  ==>  (a b c)
 
-(load-from-library "hash-table.scm")
+(load-from-library "./lib/hash-table.scm")
 
 (define (list->set a)
   (define (l->s a r)

--- a/lib/make-help-index.scm
+++ b/lib/make-help-index.scm
@@ -12,9 +12,9 @@
 ;
 ; (Example): (make-help-index)  ==>  (list of procedures and keywords)
 
-(load-from-library "flatten.scm")
-(load-from-library "list-to-set.scm")
-(load-from-library "mergesort.scm")
+(load-from-library "./lib/flatten.scm")
+(load-from-library "./lib/list-to-set.scm")
+(load-from-library "./lib/mergesort.scm")
 
 (define (make-help-index)
 

--- a/lib/mergesort.scm
+++ b/lib/mergesort.scm
@@ -10,8 +10,8 @@
 ;
 ; Example:   (mergesort <= '(5 3 7 9 1))  ==>  (1 3 5 7 9)
 
-(load-from-library "split.scm")
-(load-from-library "merge.scm")
+(load-from-library "./lib/split.scm")
+(load-from-library "./lib/merge.scm")
 
 (define (mergesort p a)
   (letrec

--- a/lib/string-find.scm
+++ b/lib/string-find.scm
@@ -28,7 +28,7 @@
 ;            (string-find-word "me" "test me")   ==>  "me"
 ;            (string-find-word "me" "testme")    ==>  #f
 
-(load-from-library "string-position.scm")
+(load-from-library "./lib/string-position.scm")
 
 (define (make-find pos)
   (lambda (u s)


### PR DESCRIPTION
These are the changes I needed to make to get a build on Mac M1 Ventura and following the instructions in README as closely as I could. I realize I should have changed `load-library` rather than prepending `./lib/` to filenames, so this PR may be at best informative. Apologies as I was in a hurry to find out whether there was any more drama on a build. There was not after I made these changes. 